### PR TITLE
point at HTTPS version of sparetimelabs repo so maven won't block it

### DIFF
--- a/vcr4j-purejavacomm/pom.xml
+++ b/vcr4j-purejavacomm/pom.xml
@@ -35,8 +35,8 @@
     <repositories>
     <repository>
         <id>sparetimelabs</id>
-        <name>sparetimelabes</name>
-        <url>http://www.sparetimelabs.com/maven2/</url>
+        <name>sparetimelabs</name>
+        <url>https://www.sparetimelabs.com/maven2/</url>
     </repository>
     </repositories>
 </project>


### PR DESCRIPTION
maven versions > 3.8.1 block all module downloads over HTTP. looks like sparetimelabs does host over HTTPS as well, so just need to update the URL here